### PR TITLE
feat/validators: Implement validate request input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.6.2
+	github.com/go-playground/validator/v10 v10.2.0
 	github.com/golang/protobuf v1.3.5
 	github.com/jinzhu/gorm v1.9.12
 	github.com/joho/godotenv v1.3.0

--- a/handler/auth.go
+++ b/handler/auth.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	"github.com/locpham24/go-authentication/model"
+	"github.com/locpham24/go-authentication/validator"
 	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"os"
@@ -26,10 +27,7 @@ func (a AuthHandler) inject() {
 func (a AuthHandler) register(c *gin.Context) {
 	input := model.UserForm{}
 	if err := c.BindJSON(&input); err != nil {
-		c.JSON(400, gin.H{
-			"code":    1000,
-			"message": err.Error(),
-		})
+		validator.HandleErrors(c, err)
 		return
 	}
 
@@ -86,10 +84,7 @@ func (a AuthHandler) login(c *gin.Context) {
 	// 1. get user info from request
 	input := model.UserForm{}
 	if err := c.BindJSON(&input); err != nil {
-		c.JSON(400, gin.H{
-			"code":    1000,
-			"message": err.Error(),
-		})
+		validator.HandleErrors(c, err)
 		return
 	}
 

--- a/handler/user.go
+++ b/handler/user.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	"github.com/locpham24/go-authentication/middleware"
@@ -29,8 +28,6 @@ func (u UserHandler) get(c *gin.Context) {
 		})
 	}
 	user := model.User{}
-
-	fmt.Println("hello")
 
 	err = u.DB.First(&user, id).Error
 	if err != nil {

--- a/model/user.go
+++ b/model/user.go
@@ -11,8 +11,8 @@ type User struct {
 }
 
 type UserForm struct {
-	Username string `json:"username" validate:"required"`
-	Password string `json:"password" validate:"required"`
+	Username string `json:"username" validate:"required" binding:"required,alphanum,min=4,max=255"`
+	Password string `json:"password" validate:"required" binding:"required,min=8,max=255"`
 }
 
 func (u *User) Fill(f UserForm) {

--- a/service/api.go
+++ b/service/api.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/jinzhu/gorm"
 	"github.com/locpham24/go-authentication/handler"
+	"github.com/locpham24/go-authentication/validator"
 )
 
 type APIService struct {
@@ -17,6 +19,7 @@ func NewAPIService(db *gorm.DB) APIService {
 }
 func (s APIService) Start() {
 	r := gin.Default()
+	binding.Validator = new(validator.DefaultValidator)
 	handler.InitRouter(r, s.db)
 	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,0 +1,90 @@
+package validator
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin/binding"
+)
+
+type DefaultValidator struct {
+	once     sync.Once
+	validate *validator.Validate
+}
+
+var _ binding.StructValidator = &DefaultValidator{}
+
+func (v *DefaultValidator) ValidateStruct(obj interface{}) error {
+
+	if kindOfData(obj) == reflect.Struct {
+
+		v.lazyinit()
+
+		if err := v.validate.Struct(obj); err != nil {
+			return error(err)
+		}
+	}
+
+	return nil
+}
+
+func (v *DefaultValidator) Engine() interface{} {
+	v.lazyinit()
+	return v.validate
+}
+
+func (v *DefaultValidator) lazyinit() {
+	v.once.Do(func() {
+		v.validate = validator.New()
+		v.validate.SetTagName("binding")
+
+		v.validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+			name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+			return name
+		})
+	})
+}
+
+func kindOfData(data interface{}) reflect.Kind {
+
+	value := reflect.ValueOf(data)
+	valueType := value.Kind()
+
+	if valueType == reflect.Ptr {
+		valueType = value.Elem().Kind()
+	}
+	return valueType
+}
+
+func HandleErrors(c *gin.Context, err error) {
+	for _, fieldErr := range err.(validator.ValidationErrors) {
+		c.JSON(http.StatusBadRequest, FieldError{fieldErr}.String())
+	}
+}
+
+type FieldError struct {
+	Err validator.FieldError
+}
+
+func (q FieldError) String() string {
+	var sb strings.Builder
+
+	sb.WriteString("validation failed on field '" + q.Err.Field() + "'")
+	sb.WriteString(", condition: " + q.Err.ActualTag())
+
+	// Print condition parameters, e.g. oneof=red blue -> { red blue }
+	if q.Err.Param() != "" {
+		sb.WriteString(" { " + q.Err.Param() + " }")
+	}
+
+	if q.Err.Value() != nil && q.Err.Value() != "" {
+		sb.WriteString(fmt.Sprintf(", actual: %v", q.Err.Value()))
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
### Description
- Validate input before processing.
- User:
    + username:
         + `required`
         + `min`: 4 characters.
         + `max`: 255 characters.
         + `alphanum`: alphanumeric.
    + password:
         + `required`
         + `min`: 8 characters.
         + `max`: 255 characters.
      

### How to test this feature
1. Check `alphanum`:
```curl
curl -XPOST http://localhost:8080/login -d '{"username": "tindt@gmail.com", "password": "password"}'
```
2. Check `min` password characters:
```curl
curl -XPOST http://localhost:8080/login -d '{"username": "tindtgmailcom", "password": "pass"}'
```
3. Check `min` username & password characters:
```curl
curl -XPOST http://localhost:8080/login -d '{"username": "tin", "password": "pass"}'
```
